### PR TITLE
Run tests in CI also with PHP 8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,71 +3,62 @@ name: CI (tests, code style and static analysis)
 on: pull_request
 
 jobs:
-    cs:
-        name: PHP CS Fixer
-        runs-on: ubuntu-latest
+  cs:
+    name: PHP CS Fixer
+    runs-on: ubuntu-latest
 
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-            - name: Install PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: '8.0'
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
 
-            - name: Check PHP Version
-              run: php -v
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
 
-            - name: Install dependencies
-              run: composer install --prefer-dist --no-progress --no-suggest
+      - name: Run PHP CS Fixer
+        run: composer cs
 
-            - name: Run PHP CS Fixer
-              run: composer cs
+  tests:
+    name: PestPHP Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions: ['8.0', '8.1', '8.2', '8.3']
 
-    tests:
-        name: PestPHP Tests
-        runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                php-versions: ['8.0', '8.1', '8.2']
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v2
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
 
-            - name: Install PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: ${{ matrix.php-versions }}
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
 
-            - name: Check PHP Version
-              run: php -v
+      - name: Run tests
+        run: composer test
 
-            - name: Install dependencies
-              run: composer install --prefer-dist --no-progress --no-suggest
+  stan:
+    name: PHPStan
+    runs-on: ubuntu-latest
 
-            - name: Run tests
-              run: composer test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    stan:
-        name: PHPStan
-        runs-on: ubuntu-latest
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
 
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v2
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
 
-            - name: Install PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: '8.0'
-
-            - name: Check PHP Version
-              run: php -v
-
-            - name: Install dependencies
-              run: composer install --prefer-dist --no-progress --no-suggest
-
-            - name: Run PHPStan
-              run: composer stan
+      - name: Run PHPStan
+        run: composer stan

--- a/src/Exceptions/InvalidJsonException.php
+++ b/src/Exceptions/InvalidJsonException.php
@@ -4,6 +4,4 @@ namespace Crwlr\Utils\Exceptions;
 
 use Exception;
 
-class InvalidJsonException extends Exception
-{
-}
+class InvalidJsonException extends Exception {}

--- a/src/Microseconds.php
+++ b/src/Microseconds.php
@@ -13,9 +13,7 @@ namespace Crwlr\Utils;
 
 class Microseconds
 {
-    public function __construct(public int $value)
-    {
-    }
+    public function __construct(public int $value) {}
 
     public static function now(): self
     {


### PR DESCRIPTION
Further reformat ci.yml with 2 indents as defined in .editorconfig, upgrade to use github actions/checkout in v4, remove deprecated option --no-suggest from composer install and some code style changes in PHP after running PHP CS Fixer in the newest version.