### PR TITLE
Fix unescaped double quotes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,31 +3,12 @@ name: CI (tests, code style and static analysis)
 on: pull_request
 
 jobs:
-  cs:
-    name: PHP CS Fixer
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.0'
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
-
-      - name: Run PHP CS Fixer
-        run: composer cs
-
   tests:
     name: PestPHP Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
 
     steps:
       - name: Checkout code
@@ -44,8 +25,8 @@ jobs:
       - name: Run tests
         run: composer test
 
-  stan:
-    name: PHPStan
+  stanAndCs:
+    name: Static Analysis (phpstan) and Code Style (PHP CS Fixer)
     runs-on: ubuntu-latest
 
     steps:
@@ -62,3 +43,6 @@ jobs:
 
       - name: Run PHPStan
         run: composer stan
+
+      - name: Run PHP CS Fixer
+        run: composer cs

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 vendor
 .php-cs-fixer.cache
 .phpunit.result.cache
+.phpunit.cache
 composer.lock

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -2,17 +2,21 @@
 
 use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
 
 $finder = Finder::create()
     ->exclude(['.github', 'bin', 'git-hooks'])
     ->in(__DIR__);
 $config = new Config();
 
-return $config->setFinder($finder)
+return (new Config())
+    ->setFinder($finder)
+    ->setParallelConfig(ParallelConfigFactory::detect())
     ->setRules([
-        '@PER' => true,
+        '@PER-CS' => true,
         'strict_param' => true,
-        'single_class_element_per_statement' => false,
+        'array_syntax' => ['syntax' => 'short'],
+        'no_unused_imports' => true,
     ])
     ->setRiskyAllowed(true)
     ->setUsingCache(true);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2024-11-20
+### Fixed
+- Improve parsing invalid JSON by detecting and fixing unescaped double quote characters inside string values.
+
 ## [1.1.0] - 2023-07-20
 - The `Microseconds` value object class that wraps timestamp float values to make it easier and less error-prone to work with.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2023 Christian Olear
+Copyright (c) 2024 Christian Olear
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,9 @@
         "php": "^8.0"
     },
     "require-dev": {
-        "pestphp/pest": "^1.22",
+        "pestphp/pest": "^1.22|^2.0|^3.0",
         "phpstan/phpstan": "^1.8",
-        "friendsofphp/php-cs-fixer": "^3.11"
+        "friendsofphp/php-cs-fixer": "^3.57"
     },
     "scripts": {
         "test": "@php vendor/bin/pest",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,5 +3,6 @@ parameters:
     paths:
         - src
         - tests
+    reportUnmatchedIgnoredErrors: false
     ignoreErrors:
         - "#^Call to an undefined method Pest\\\\Expectation\\|Pest\\\\Support\\\\Extendable\\:\\:\\S+\\(\\)\\.$#"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,18 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true"
->
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">./app</directory>
-            <directory suffix=".php">./src</directory>
-        </include>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache">
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">./app</directory>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Json.php
+++ b/src/Json.php
@@ -27,14 +27,17 @@ class Json
     }
 
     /**
-     * Try to fix JSON keys without quotes
+     * Try to fix an invalid JSON string
      *
+     * 1) Try to fix JSON keys without quotes
      * PHPs json_decode() doesn't work with JSON objects where the keys are not wrapped in quotes.
      * This method tries to fix this, when json_decode() fails to parse a JSON string.
+     *
+     * 2) Try to fix unescaped double quotes within a string value
      */
     protected static function fixJsonString(string $jsonString): string
     {
-        return preg_replace_callback(
+        $jsonString = preg_replace_callback(
             '/(?:(\w+):(\s*".*?"\s*(?:,|}))|(\w+):(\s*[^"]+?\s*(?:,|})))/i',
             function ($match) {
                 if (count($match) === 3) {
@@ -59,7 +62,20 @@ class Json
 
                 return $key . ':' . $value;
             },
-            $jsonString
+            $jsonString,
         ) ?? $jsonString;
+
+        // If JSON string contains unescaped double quotes inside a string value, try to fix it.
+        if (preg_match('/".+?": "(.+(?<!\\\\)".+)"\s*?(,|})/', $jsonString)) {
+            $jsonString = preg_replace_callback('/".+?": "(.+(?<!\\\\)".+)"\s*?(,|})/', function ($match) {
+                return str_replace(
+                    $match[1],
+                    str_replace('"', '\"', $match[1]),
+                    $match[0],
+                );
+            }, $jsonString) ?? $jsonString;
+        }
+
+        return $jsonString;
     }
 }

--- a/tests/JsonTest.php
+++ b/tests/JsonTest.php
@@ -61,6 +61,20 @@ it('correctly fixes keys without quotes, when the value is an empty string', fun
     ]);
 });
 
+it('fixes unescaped double quotes inside a string value', function () {
+    $jsonString = <<<JSON
+        {
+            "foo": "bar "lorem" ipsum baz",
+            "bar": "lets "do" "" "even more"
+        }
+        JSON;
+
+    expect(Json::stringToArray($jsonString))->toBe([
+        'foo' => 'bar "lorem" ipsum baz',
+        'bar' => 'lets "do" "" "even more',
+    ]);
+});
+
 it('throws an exception when the string is not a (valid) JSON string', function () {
     Json::stringToArray('{ foo: bar ]');
 })->throws(InvalidJsonException::class);

--- a/tests/MicrosecondsTest.php
+++ b/tests/MicrosecondsTest.php
@@ -16,7 +16,7 @@ it('adds the value of another instance to its own value', function () {
     expect(
         Microseconds::fromSeconds(2.23)
             ->add(Microseconds::fromSeconds(3.37))
-            ->toSeconds()
+            ->toSeconds(),
     )->toBe(5.6);
 });
 
@@ -24,7 +24,7 @@ it('subtracts the value of another instance from its own value', function () {
     expect(
         Microseconds::fromSeconds(5.35)
             ->subtract(Microseconds::fromSeconds(2.20))
-            ->toSeconds()
+            ->toSeconds(),
     )->toBe(3.15);
 });
 
@@ -33,9 +33,9 @@ it(
     function (float $value, float $greaterThan, bool $result) {
         expect(
             Microseconds::fromSeconds($value)
-                ->isGreaterThan(Microseconds::fromSeconds($greaterThan))
+                ->isGreaterThan(Microseconds::fromSeconds($greaterThan)),
         )->toBe($result);
-    }
+    },
 )->with([
     [1.2345, 1.2344, true],
     [1.2345, 1.2345, false],
@@ -47,9 +47,9 @@ it(
     function (float $value, float $greaterThan, bool $result) {
         expect(
             Microseconds::fromSeconds($value)
-                ->isGreaterThanOrEqual(Microseconds::fromSeconds($greaterThan))
+                ->isGreaterThanOrEqual(Microseconds::fromSeconds($greaterThan)),
         )->toBe($result);
-    }
+    },
 )->with([
     [1.2345, 1.2344, true],
     [1.2345, 1.2345, true],
@@ -61,9 +61,9 @@ it(
     function (float $value, float $greaterThan, bool $result) {
         expect(
             Microseconds::fromSeconds($value)
-                ->isLessThan(Microseconds::fromSeconds($greaterThan))
+                ->isLessThan(Microseconds::fromSeconds($greaterThan)),
         )->toBe($result);
-    }
+    },
 )->with([
     [1.2345, 1.2344, false],
     [1.2345, 1.2345, false],
@@ -75,9 +75,9 @@ it(
     function (float $value, float $lessThanOrEqual, bool $result) {
         expect(
             Microseconds::fromSeconds($value)
-                ->isLessThanOrEqual(Microseconds::fromSeconds($lessThanOrEqual))
+                ->isLessThanOrEqual(Microseconds::fromSeconds($lessThanOrEqual)),
         )->toBe($result);
-    }
+    },
 )->with([
     [1.2345, 1.2346, true],
     [1.2345, 1.2345, true],


### PR DESCRIPTION
Improve parsing invalid JSON by detecting and fixing unescaped double quote characters inside string values.

Also run tests on PHP 8.4 in github actions, allow newer PEST versions, run PHP CS Fixer in parallel and other minor dev improvements.